### PR TITLE
Add Mod TownOfHostEnhanced

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - **[TownOfHostEdited](https://aumod.site/archives/TownOfHostEdited)** An Amongs mod with learning & love.
 - **[TownOfHostEditedXi](https://aumod.site/archives/TownOfHostEditedXi)** Host Only mod forked from Town Of Host Edited.
 - **[EndlessHostRoles](https://aumod.site/archives/EndlessHostRoles)** EHR is the biggest host-only mod for Among Us, with over 400 roles and 10 game modes, along with a Custom Team Assigner application to fully customize your games!
+- **[TownOfHostEnhanced](https://aumod.site/archives/TownOfHostEnhanced)** TOHE is the best Host-Only mod for anyone who wants to change their Among Us Experience!
 ### 非H模组
 - **[TheOtherRoles](https://aumod.site/archives/TheOtherRoles)** The Other Roles, is a mod for Among Us which adds many new roles, new Settings and new Custom Hats to the game.
 - **[SuperNewRoles](https://aumod.site/archives/SuperNewRoles)** モードや役職など、様々な要素があるAmongUsのMOD、SuperNewRoles!!!!


### PR DESCRIPTION
TownOfHostEnhanced在之前的网站中因标签与TownOfHostEdited的别名冲突,致使TownOfHostEnhanced的收录一拖再拖。
但现在,标签别名策略早已被更改,这使得这个问题自然而然被化解了。
因此我认为是时候收录TownOfHostEnhanced了。