### PR TITLE
Add Mod Lotus

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - **[TownOfHostEditedXi](https://aumod.site/archives/TownOfHostEditedXi)** Host Only mod forked from Town Of Host Edited.
 - **[EndlessHostRoles](https://aumod.site/archives/EndlessHostRoles)** EHR is the biggest host-only mod for Among Us, with over 400 roles and 10 game modes, along with a Custom Team Assigner application to fully customize your games!
 - **[TownOfHostEnhanced](https://aumod.site/archives/TownOfHostEnhanced)** TOHE is the best Host-Only mod for anyone who wants to change their Among Us Experience!
+- **[Lotus](https://aumod.site/archives/Lotus)** A unique host-only Among Us mod to enrich your experience.
 ### 非H模组
 - **[TheOtherRoles](https://aumod.site/archives/TheOtherRoles)** The Other Roles, is a mod for Among Us which adds many new roles, new Settings and new Custom Hats to the game.
 - **[SuperNewRoles](https://aumod.site/archives/SuperNewRoles)** モードや役職など、様々な要素があるAmongUsのMOD、SuperNewRoles!!!!


### PR DESCRIPTION
> [!Note]
> 收录版本为[延续版本](https://github.com/Lotus-AU/LotusContinued)。

在Lotus**发布多个正式版之前**,AuModSite**不会收录**该模组。

实际上,按照AuModSite的模组收录标准是**不会考虑**收录Lotus的。
但由于Lotus拥有6500+次commit,近6个月内仍有提交记录且模组UI风格别具一格,我们认为等一等这个模组也无妨。